### PR TITLE
Suport hostedDomain

### DIFF
--- a/lib/passport-configurator.js
+++ b/lib/passport-configurator.js
@@ -15,10 +15,11 @@ var _ = require('underscore');
 module.exports = PassportConfigurator;
 
 /**
- * @class
- * @classdesc The passport configurator
+ * The passport configurator
  * @param {Object} app The LoopBack app instance
  * @returns {PassportConfigurator}
+ * @constructor
+ * @class
  */
 function PassportConfigurator(app) {
   if (!(this instanceof PassportConfigurator)) {
@@ -110,7 +111,7 @@ PassportConfigurator.prototype.init = function(noSession) {
  * @param {Object} user The user's attributes from ldap
  * @param {Object} options Ldap provider options, with mapping definition in
  * options.profileAttributesFromLDAP
- * @returns {Object} user profile
+ * @return {Object} user profile
  * @end
  */
 PassportConfigurator.prototype.buildUserLdapProfile = function(user, options) {
@@ -156,6 +157,7 @@ PassportConfigurator.prototype.buildUserLdapProfile = function(user, options) {
  * @property {String} [callbackURL] oAuth 2.0 callback URL.
  * @property {String} [callbackPath] oAuth 2.0 callback route.
  * @property {String} [scope] oAuth 2.0 scopes.
+ * @property {String} [hd] oAuth 2.0 hostedDomain.
  * @property {String} [successRedirect] The redirect route if login succeeds.
  * For both oAuth 1 and 2.
  * @property {String} [failureRedirect] The redirect route if login fails.
@@ -236,6 +238,7 @@ PassportConfigurator.prototype.configureProvider = function(name, options) {
   var failureRedirect = options.failureRedirect ||
     (link ? '/link.html' : '/login.html');
   var scope = options.scope;
+  var hd = options.hd;
   var authType = authScheme.toLowerCase();
 
   var session = !!options.session;
@@ -555,7 +558,7 @@ PassportConfigurator.prototype.configureProvider = function(name, options) {
         }
       })(req, res, next);
   };
-  /*!
+  /*
    * Setup the authentication request URLs.
    */
   if (authType === 'local') {
@@ -580,10 +583,11 @@ PassportConfigurator.prototype.configureProvider = function(name, options) {
     self.app.get(authPath, passport.authenticate(name, _.defaults({
       scope: scope,
       session: session,
+      hd: hd,
     }, options.authOptions)));
   }
 
-  /*!
+  /*
    * Setup the authentication callback URLs.
    */
   if (link) {


### PR DESCRIPTION
Suport hostedDomain for google oAuth 2.0

### Description
Use the hd parameter to optimize the OpenID Connect flow for users of a particular G Suite domain. 

providers,json

"google-login": {
    "provider": "google",
    "module": "passport-google-oauth",
    "strategy": "OAuth2Strategy",
    "clientID": "",
    "clientSecret": "",
    "callbackURL": "/auth/google/callback",
    "authPath": "/auth/google",
    "callbackPath": "/auth/google/callback",
    "successRedirect": "/auth/account",
    "failureRedirect": "/login",
    "scope": ["email", "profile"],
    "hd": "example.com", 
    "failureFlash": true
  }